### PR TITLE
Adding utility for handling namespaced N-V-R strings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,8 @@ addopts = "--cov --cov-config .coveragerc --cov-report term --cov-report xml --c
 
 [tool.ruff]
 line-length = 100
+target-version = "py37"  # Really 3.6, but ruff's floor is 3.7
+
+[tool.ruff.lint]
+ignore = ["FA100"]  # typing.Dict/Union needed for Python 3.6 compat
+

--- a/rpmautospec_core/__init__.py
+++ b/rpmautospec_core/__init__.py
@@ -3,3 +3,11 @@ from .main import (  # noqa: F401
     check_specfile_features,
     specfile_uses_rpmautospec,
 )
+from .nvr_util import (  # noqa: F401
+    NVR,
+    epoch_version,
+    format_namespaced_nvr,
+    format_nvr,
+    parse_namespaced_nvr,
+    parse_nvr,
+)

--- a/rpmautospec_core/main.py
+++ b/rpmautospec_core/main.py
@@ -4,7 +4,6 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Union
 
-
 # the %autorelease macro including parameters
 AUTORELEASE_MACRO = "autorelease(e:s:pb:n)"
 

--- a/rpmautospec_core/nvr_util.py
+++ b/rpmautospec_core/nvr_util.py
@@ -1,0 +1,101 @@
+from collections import namedtuple
+
+# Utilities for parsing and formatting namespaced N-V-R strings stored as
+# git tags. An external system creates tags in the format:
+#
+#     {namespace}/[E!]N-V-R
+#
+# [E!]N-V-R is the package's Name-Version-Release with an optional epoch
+# prefix. rpmautospec can read these tags to determine release history.
+
+# In RPM, epochs are normally separated by a colon (e.g. "2:httpd-2.4.57-1"),
+# but colons are not permitted in git ref names. We use "!" as the epoch
+# separator instead (e.g. "2!httpd-2.4.57-1"). RPM treats epoch 0 as the
+# implicit default, so only non-zero epochs are encoded in the tag.
+GIT_TAG_EPOCH_SEPARATOR = "!"
+
+NVR = namedtuple("NVR", ["name", "epoch", "version", "release"])
+
+
+def parse_namespaced_nvr(tag_name: str, namespace: str) -> NVR:
+    """Parse [E!]N-V-R from a git tag name under the given namespace.
+
+    Expected format: {namespace}/[E!]N-V-R
+
+    :param tag_name: the tag name (without refs/tags/)
+    :param namespace: the namespace path to strip (e.g. "fedora/f44")
+    :return: NVR namedtuple with name, epoch, version, release fields
+    :raises ValueError: if tag_name doesn't belong to namespace or is unparseable
+    """
+    tagged_ns, remainder = tag_name.rsplit("/", 1)
+    if tagged_ns != namespace:
+        raise ValueError(f"Unexpected namespace: {tagged_ns!r} != {namespace!r}")
+    return parse_nvr(remainder)
+
+
+def parse_nvr(nvr: str) -> NVR:
+    """Parse an [E!]N-V-R string into its components.
+
+    Format: [E!]N-V-R where E is a numeric epoch (optional),
+    N is the package name, V is version, R is release.
+
+    :param nvr: an [E!]N-V-R string
+    :return: NVR namedtuple with name, epoch, version, release fields
+    :raises ValueError: if nvr cannot be parsed
+    """
+    try:
+        epoch_name, version, release = nvr.rsplit("-", 2)
+    except ValueError:
+        raise ValueError(f"Cannot parse NVR: {nvr!r}")
+    if not all((epoch_name, version, release)):
+        raise ValueError(f"Cannot parse NVR: {nvr!r}")
+    try:
+        epoch, name = epoch_name.split(GIT_TAG_EPOCH_SEPARATOR, 1)
+    except ValueError:
+        epoch = ""
+        name = epoch_name
+    else:
+        if not epoch.isdigit():
+            raise ValueError(f"Epoch must be all digits, is {epoch!r}")
+        if not name:
+            raise ValueError(f"Empty name after epoch in NVR: {nvr!r}")
+    return NVR(name=name, epoch=epoch, version=version, release=release)
+
+
+def format_namespaced_nvr(namespace: str, name: str, epoch: str, version: str, release: str) -> str:
+    """Create a namespaced [E!]N-V-R tag name.
+
+    :param namespace: namespace path (e.g. "fedora/f44")
+    :param name: package name
+    :param epoch: epoch number as string, or empty for no epoch
+    :param version: package version
+    :param release: release number (without dist suffix)
+    :return: formatted tag name (e.g. "fedora/f44/mesa-26.0.7-2")
+    """
+    nvr = format_nvr(name, epoch, version, release)
+    return f"{namespace}/{nvr}"
+
+
+def format_nvr(name: str, epoch: str, version: str, release: str) -> str:
+    """Create an [E!]N-V-R string (with optional epoch prefix).
+
+    :param name: package name
+    :param epoch: epoch number as string; empty or "0" yields no epoch prefix
+    :param version: package version
+    :param release: package release number (raw number, no suffix/etc)
+    :return: formatted package [E!]N-V-R
+    """
+    if epoch and epoch != "0":
+        return f"{epoch}{GIT_TAG_EPOCH_SEPARATOR}{name}-{version}-{release}"
+    return f"{name}-{version}-{release}"
+
+
+def epoch_version(nvr: NVR) -> str:
+    """Reconstruct epoch-version string from a parsed NVR.
+
+    :param nvr: NVR namedtuple with epoch and version fields
+    :return: "epoch:version" if epoch is set and non-zero, otherwise just "version"
+    """
+    if nvr.epoch and nvr.epoch != "0":
+        return f"{nvr.epoch}:{nvr.version}"
+    return nvr.version

--- a/tests/test_nvr_util.py
+++ b/tests/test_nvr_util.py
@@ -1,0 +1,164 @@
+import pytest
+
+from rpmautospec_core.nvr_util import (
+    NVR,
+    epoch_version,
+    format_namespaced_nvr,
+    format_nvr,
+    parse_namespaced_nvr,
+    parse_nvr,
+)
+
+
+class TestParseNvr:
+    """Tests for parse_nvr — the core NVR parsing logic."""
+
+    @pytest.mark.parametrize(
+        "nvr",
+        [
+            "pkg",
+            "pkg-1.0",
+            "-1.0-1",
+            "pkg--1",
+            "pkg-1.0-",
+            # Non-numeric epoch
+            "foo!pkg-1.0-1",
+            # Empty name after epoch
+            "2!-1.0-1",
+        ],
+    )
+    def test_invalid(self, nvr):
+        with pytest.raises(ValueError):
+            parse_nvr(nvr)
+
+    @pytest.mark.parametrize(
+        "nvr, expected",
+        [
+            ("mesa-26.0.7-2", NVR(name="mesa", epoch="", version="26.0.7", release="2")),
+            (
+                "python-requests-2.28.1-1",
+                NVR(name="python-requests", epoch="", version="2.28.1", release="1"),
+            ),
+            (
+                "kernel-6.8.0-0.rc6.47.fc40",
+                NVR(name="kernel", epoch="", version="6.8.0", release="0.rc6.47.fc40"),
+            ),
+            # Underscore in version preserved (legal in RPM)
+            ("pkg-1.0_rc1-2", NVR(name="pkg", epoch="", version="1.0_rc1", release="2")),
+            # Epoch encoded with !
+            (
+                "2!httpd-2.4.57-1",
+                NVR(name="httpd", epoch="2", version="2.4.57", release="1"),
+            ),
+            ("0!pkg-1.0-3", NVR(name="pkg", epoch="0", version="1.0", release="3")),
+            ("10!pkg-2.0-1", NVR(name="pkg", epoch="10", version="2.0", release="1")),
+        ],
+    )
+    def test_valid(self, nvr, expected):
+        assert parse_nvr(nvr) == expected
+
+
+class TestFormatNvr:
+    """Tests for format_nvr."""
+
+    def test_simple(self):
+        assert format_nvr("mesa", "", "26.0.7", "2") == "mesa-26.0.7-2"
+
+    def test_with_epoch(self):
+        assert format_nvr("httpd", "2", "2.4.57", "1") == "2!httpd-2.4.57-1"
+
+    def test_epoch_zero(self):
+        # Epoch 0 is RPM's default and equivalent to absent; no prefix emitted.
+        assert format_nvr("pkg", "0", "1.0", "3") == "pkg-1.0-3"
+
+    def test_no_epoch(self):
+        assert format_nvr("pkg", "", "1.0", "1") == "pkg-1.0-1"
+
+    def test_roundtrip(self):
+        nvr = format_nvr("python-requests", "", "2.28.1", "1")
+        assert parse_nvr(nvr) == NVR(
+            name="python-requests",
+            epoch="",
+            version="2.28.1",
+            release="1",
+        )
+
+    def test_roundtrip_with_epoch(self):
+        nvr = format_nvr("httpd", "2", "2.4.57", "1")
+        assert parse_nvr(nvr) == NVR(
+            name="httpd",
+            epoch="2",
+            version="2.4.57",
+            release="1",
+        )
+
+
+class TestParseNamespacedNvr:
+    """Tests for parse_namespaced_nvr — namespace stripping."""
+
+    def test_wrong_namespace(self):
+        with pytest.raises(ValueError):
+            parse_namespaced_nvr("other/ns/pkg-1.0-1", "fedora/f44")
+
+    def test_basic(self):
+        result = parse_namespaced_nvr("fedora/f44/mesa-26.0.7-2", "fedora/f44")
+        assert result == NVR(name="mesa", epoch="", version="26.0.7", release="2")
+
+    def test_with_epoch(self):
+        result = parse_namespaced_nvr("fedora/f44/2!httpd-2.4.57-1", "fedora/f44")
+        assert result == NVR(name="httpd", epoch="2", version="2.4.57", release="1")
+
+    def test_invalid_nvr_after_namespace(self):
+        with pytest.raises(ValueError):
+            parse_namespaced_nvr("fedora/f44/pkg", "fedora/f44")
+
+    def test_alternate_namespace(self):
+        result = parse_namespaced_nvr("fedora/f43/mesa-1.0-1", "fedora/f43")
+        assert result == NVR(name="mesa", epoch="", version="1.0", release="1")
+
+
+class TestFormatNamespacedNvr:
+    """Tests for format_namespaced_nvr."""
+
+    def test_basic(self):
+        assert (
+            format_namespaced_nvr("fedora/f44", "mesa", "", "26.0.7", "2")
+            == "fedora/f44/mesa-26.0.7-2"
+        )
+
+    def test_with_epoch(self):
+        assert format_namespaced_nvr("fedora/f44", "httpd", "2", "2.4.57", "1") == (
+            "fedora/f44/2!httpd-2.4.57-1"
+        )
+
+    def test_epoch_zero_omitted(self):
+        assert format_namespaced_nvr("fedora/f44", "pkg", "0", "1.0", "1") == (
+            "fedora/f44/pkg-1.0-1"
+        )
+
+    def test_roundtrip(self):
+        tag = format_namespaced_nvr("fedora/f44", "python-requests", "", "2.28.1", "1")
+        parsed = parse_namespaced_nvr(tag, "fedora/f44")
+        assert parsed == NVR(
+            name="python-requests",
+            epoch="",
+            version="2.28.1",
+            release="1",
+        )
+
+
+class TestEpochVersion:
+    """Tests for epoch_version helper."""
+
+    def test_with_epoch(self):
+        assert epoch_version(NVR(name="x", epoch="2", version="1.0", release="1")) == "2:1.0"
+
+    def test_epoch_zero(self):
+        # Epoch 0 is equivalent to absent; RPM omits it.
+        assert epoch_version(NVR(name="x", epoch="0", version="1.0", release="1")) == "1.0"
+
+    def test_without_epoch(self):
+        assert epoch_version(NVR(name="x", epoch="", version="1.0", release="1")) == "1.0"
+
+    def test_no_epoch_key(self):
+        assert epoch_version(NVR(name="x", epoch="", version="1.0", release="1")) == "1.0"


### PR DESCRIPTION
[I have added mechanics to Rpmautospec to use namespaced tags of N-V-Rs to codify release history & enhance autorelease/autochangelog to better reflect reality.](https://github.com/fedora-infra/rpmautospec/pull/397) To support this, I have added standard encode/decode of the namespaced n-v-r tag structure into Rpmautospec-core. This includes handling of Epoch for NEVR: ':' is not legal in git refs, so I have elected to use '!' instead (the Debian standard, for comparison, is to use '%', but I did not want confusion w/ RPM macro format).

I have bumped minor version given this is new functionality/enhancement and to better delineate dependency versions across all Rpmautospec component packages.